### PR TITLE
kotlin-stdlib-jdk8 instead of kotlin-stdlib-jre8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ compileTestKotlin {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"


### PR DESCRIPTION
According to http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages, kotlin-stdlib-jre8 is deprecated.