### PR TITLE
Strange hack to make Gradle always rerun the tests 

### DIFF
--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -21,4 +21,5 @@ task GenerateTests(type: JavaExec) {
 task TestExamples(type: Test, dependsOn: testClasses) {
     include 'TestExamples.class'
     description = "Runs tests checking output and 'eq' in examples"
+    systemProperty "random.testing.seed", new Random().nextInt()
 }


### PR DESCRIPTION
...even if there're no changes in the code

In our case, there might be changes in Output comments that change test behaviour